### PR TITLE
Updated routes for Activities

### DIFF
--- a/backend/init-scripts/init.sql
+++ b/backend/init-scripts/init.sql
@@ -246,6 +246,9 @@ ALTER TABLE
 ALTER TABLE
     "glucose_stat" ADD CONSTRAINT "glucose_stat_stat_id_foreign" FOREIGN KEY("stat_id") REFERENCES "stat"("id");
 
+
+CREATE VIEW "active_activity" AS 
+SELECT * FROM "activity" WHERE "date_archived" IS NULL;
 ----------------------------------------------------------------------------------------------------------------
 --------------------------------------------- POPULATE ENUM TABLES ---------------------------------------------
 ----------------------------------------------------------------------------------------------------------------

--- a/backend/routes/activities.js
+++ b/backend/routes/activities.js
@@ -63,7 +63,7 @@ router.get("/:petId/all/:activityTypeOrId", async (req, res, next) => {
 });
 
 
-// GET grab duration_in_hours vs activity_date by activity type for graphing x and y units for a specific pet
+// GET duration_in_hours vs activity_date by activity type for graphing x and y units for a specific pet
 router.get("/:petId/all/:activityTypeOrId/graph", async (req, res, next) => {
 	try {
     const { activityTypeOrId, petId } = req.params;

--- a/backend/routes/activities.js
+++ b/backend/routes/activities.js
@@ -1,16 +1,124 @@
-import express from 'express';
-import pool from '../config/database.js';
+import express from "express";
+import pool from "../config/database.js";
 const router = express.Router();
 
+// router: /activities
+
 // GET all activity types
-router.get('/', async (req, res, next) => {
+router.get(/^\/(types)?$/, async (req, res, next) => {
+	try {
+		const result = await pool.query("SELECT * FROM activity_type");
+		res.json(result.rows.map((row) => row.name));
+	} catch (err) {
+		console.error(err);
+		next(err);
+	}
+});
+
+// GET all activity data logs
+router.get("/all", async (req, res, next) => {
+	try {
+		const result = await pool.query(
+			"SELECT duration_in_hours, note, activity_date, name FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id"
+		);
+		res.json(result.rows);
+	} catch (err) {
+		console.error(err);
+		next(err);
+	}
+});
+
+// GET all activity data logs by activity type or id
+router.get("/all/:activityTypeOrId", async (req, res, next) => {
+	try {
+    const { activityTypeOrId } = req.params;
+    let result; 
+    if (!isNaN(activityTypeOrId)) {
+      result = await pool.query(
+        "SELECT duration_in_hours, note, activity_date, name FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE activity_type_id = $1",
+        [activityTypeOrId]
+      );
+
+    }
+    else{
+      const nameResult = await pool.query(
+        `SELECT name FROM activity_type WHERE LOWER(name) = LOWER($1)`,
+        [activityTypeOrId]
+      )
+      const properName = nameResult.rows[0].name;
+      if(properName !== activityTypeOrId) return res.redirect(`/activities/all/${properName}`); //redirect to the correct case
+
+      result = await pool.query(
+        "SELECT duration_in_hours, note, activity_date, name FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE LOWER(name) = LOWER($1)",
+        [activityTypeOrId]
+      );
+    }
+		res.json(result.rows);
+	} catch (err) {
+		console.error(err);
+		next(err);
+	}
+});
+
+
+// GET grab duration_in_hours vs activity_date by activity type for graphing
+router.get("/all/:activityTypeOrId/graph", async (req, res, next) => {
+	try {
+    const { activityTypeOrId } = req.params;
+    let result; 
+    if (!isNaN(activityTypeOrId)) {
+      result = await pool.query(
+        "SELECT duration_in_hours, activity_date FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE activity_type_id = $1",
+        [activityTypeOrId]
+      );
+
+    }
+    else{
+      const nameResult = await pool.query(
+        `SELECT name FROM activity_type WHERE LOWER(name) = LOWER($1)`,
+        [activityTypeOrId]
+      )
+      const properName = nameResult.rows[0].name;
+      if(properName !== activityTypeOrId) return res.redirect(`/activities/all/${properName}`); //redirect to the correct case
+
+      result = await pool.query(
+        "SELECT duration_in_hours, activity_date FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE LOWER(name) = LOWER($1)",
+        [activityTypeOrId]
+      );
+    }
+		res.json(result.rows);
+	} catch (err) {
+		console.error(err);
+		next(err);
+	}
+});
+
+// DELETE activity data log by id; since data logs is a soft delete then a hard delete after a certain time, we will follow through with a delete route and it makes the most sense with the user action. 
+
+// we always update the table not the view 
+
+router.delete("/:id", async (req, res, next) => {
   try {
-    const result = await pool.query("SELECT * FROM activity_type");
-    res.json(result.rows.map((row) => row.name));
+    const { id } = req.params;
+    const result = await pool.query("UPDATE activity SET date_archived = NOW() WHERE id = $1", [id]);
+    res.json({ message: result + ", Activity log deleted" });
   } catch (err) {
     console.error(err);
     next(err);
   }
 });
+
+// GET all deleted activity data logs (users who want to recover their data logs)
+router.get("/deleted", async (req, res, next) => {
+  try {
+    const result = await pool.query("SELECT * FROM activity WHERE date_archived IS NOT NULL");
+    res.json(result.rows);
+  } catch (err) {
+    console.error(err);
+    next(err);
+  }
+});
+
+
 
 export default router;

--- a/backend/routes/activities.js
+++ b/backend/routes/activities.js
@@ -4,7 +4,7 @@ const router = express.Router();
 
 // router: /activities
 
-// GET all activity types
+// GET all activity types at / or /types
 router.get(/^\/(types)?$/, async (req, res, next) => {
 	try {
 		const result = await pool.query("SELECT * FROM activity_type");
@@ -15,11 +15,13 @@ router.get(/^\/(types)?$/, async (req, res, next) => {
 	}
 });
 
-// GET all activity data logs
-router.get("/all", async (req, res, next) => {
+// GET all activity data logs for a specific pet
+router.get("/:petId/all", async (req, res, next) => {
 	try {
+    const { petId } = req.params;
 		const result = await pool.query(
-			"SELECT duration_in_hours, note, activity_date, name FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id"
+			"SELECT duration_in_hours, note, activity_date, name FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE pet_id = $1",
+      [petId]
 		);
 		res.json(result.rows);
 	} catch (err) {
@@ -28,15 +30,15 @@ router.get("/all", async (req, res, next) => {
 	}
 });
 
-// GET all activity data logs by activity type or id
-router.get("/all/:activityTypeOrId", async (req, res, next) => {
+// GET all activity data logs by activity type or activity type id for a specific pet
+router.get("/:petId/all/:activityTypeOrId", async (req, res, next) => {
 	try {
-    const { activityTypeOrId } = req.params;
+    const { activityTypeOrId, petId } = req.params;
     let result; 
     if (!isNaN(activityTypeOrId)) {
       result = await pool.query(
-        "SELECT duration_in_hours, note, activity_date, name FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE activity_type_id = $1",
-        [activityTypeOrId]
+        "SELECT duration_in_hours, note, activity_date, name FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE activity_type_id = $1 AND pet_id = $2",
+        [activityTypeOrId, petId]
       );
 
     }
@@ -46,11 +48,11 @@ router.get("/all/:activityTypeOrId", async (req, res, next) => {
         [activityTypeOrId]
       )
       const properName = nameResult.rows[0].name;
-      if(properName !== activityTypeOrId) return res.redirect(`/activities/all/${properName}`); //redirect to the correct case
+      if(properName !== activityTypeOrId) return res.redirect(`/activities/${petId}/all/${properName}`); //redirect to the correct case
 
       result = await pool.query(
-        "SELECT duration_in_hours, note, activity_date, name FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE LOWER(name) = LOWER($1)",
-        [activityTypeOrId]
+        "SELECT duration_in_hours, note, activity_date, name FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE LOWER(name) = LOWER($1) AND pet_id = $2",
+        [activityTypeOrId, petId]
       );
     }
 		res.json(result.rows);
@@ -61,15 +63,15 @@ router.get("/all/:activityTypeOrId", async (req, res, next) => {
 });
 
 
-// GET grab duration_in_hours vs activity_date by activity type for graphing
-router.get("/all/:activityTypeOrId/graph", async (req, res, next) => {
+// GET grab duration_in_hours vs activity_date by activity type for graphing x and y units for a specific pet
+router.get("/:petId/all/:activityTypeOrId/graph", async (req, res, next) => {
 	try {
-    const { activityTypeOrId } = req.params;
+    const { activityTypeOrId, petId } = req.params;
     let result; 
     if (!isNaN(activityTypeOrId)) {
       result = await pool.query(
-        "SELECT duration_in_hours, activity_date FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE activity_type_id = $1",
-        [activityTypeOrId]
+        "SELECT duration_in_hours, activity_date FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE activity_type_id = $1 AND pet_id = $2",
+        [activityTypeOrId, petId]
       );
 
     }
@@ -79,11 +81,11 @@ router.get("/all/:activityTypeOrId/graph", async (req, res, next) => {
         [activityTypeOrId]
       )
       const properName = nameResult.rows[0].name;
-      if(properName !== activityTypeOrId) return res.redirect(`/activities/all/${properName}`); //redirect to the correct case
+      if(properName !== activityTypeOrId) return res.redirect(`/activities/${petId}/all/${properName}`); //redirect to the correct case
 
       result = await pool.query(
-        "SELECT duration_in_hours, activity_date FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE LOWER(name) = LOWER($1)",
-        [activityTypeOrId]
+        "SELECT duration_in_hours, activity_date FROM active_activity JOIN activity_type ON active_activity.activity_type_id = activity_type.id WHERE LOWER(name) = LOWER($1) AND pet_id = $2",
+        [activityTypeOrId, petId]
       );
     }
 		res.json(result.rows);
@@ -93,15 +95,15 @@ router.get("/all/:activityTypeOrId/graph", async (req, res, next) => {
 	}
 });
 
-// DELETE activity data log by id; since data logs is a soft delete then a hard delete after a certain time, we will follow through with a delete route and it makes the most sense with the user action. 
+// DELETE activity data log by id; since data logs is a soft delete then a hard delete after a certain time (30 days), we will follow through with a delete route and it makes the most sense with the user action. 
 
 // we always update the table not the view 
 
 router.delete("/:id", async (req, res, next) => {
   try {
     const { id } = req.params;
-    const result = await pool.query("UPDATE activity SET date_archived = NOW() WHERE id = $1", [id]);
-    res.json({ message: result + ", Activity log deleted" });
+    const result = await pool.query("UPDATE activity SET date_archived = NOW() AND date_updated = NOW() WHERE id = $1", [id]);
+    res.json({ message: `id ${id}, Activity log deleted` });
   } catch (err) {
     console.error(err);
     next(err);
@@ -109,9 +111,11 @@ router.delete("/:id", async (req, res, next) => {
 });
 
 // GET all deleted activity data logs (users who want to recover their data logs)
-router.get("/deleted", async (req, res, next) => {
+// Only date_created, pet_id, date_updated and activity_type_id seems useless to show to the user and frontend
+router.get("/:petId/deleted", async (req, res, next) => {
   try {
-    const result = await pool.query("SELECT * FROM activity WHERE date_archived IS NOT NULL");
+    const { petId } = req.params;
+    const result = await pool.query("SELECT activity.id, duration_in_hours, note, date_archived, activity_date, name FROM activity JOIN activity_type ON activity.activity_type_id = activity_type.id WHERE date_archived IS NOT NULL AND pet_id = $1", [petId]);
     res.json(result.rows);
   } catch (err) {
     console.error(err);

--- a/backend/routes/petBreeds.js
+++ b/backend/routes/petBreeds.js
@@ -13,7 +13,7 @@ router.get('/', async (req, res, next) => {
   }
 });
 
-// GET pet breeds by species name or ID
+// GET pet breeds by pet species name or pet species id
 router.get('/:speciesOrId', async (req, res, next) => {
   try {
     const { speciesOrId } = req.params;

--- a/backend/routes/petBreeds.js
+++ b/backend/routes/petBreeds.js
@@ -21,11 +21,14 @@ router.get('/:speciesOrId', async (req, res, next) => {
     if (!isNaN(speciesOrId)) speciesId = Number(speciesOrId);
     else {
       const speciesQuery = await pool.query(
-        'SELECT id FROM pet_species WHERE LOWER(species) = LOWER($1)',
+        'SELECT * FROM pet_species WHERE LOWER(species) = LOWER($1)',
         [speciesOrId]
       );
       if (speciesQuery.rows.length === 0) return res.status(404).json({ error: 'Species not found' });
       speciesId = speciesQuery.rows[0].id;
+      const speciesName = speciesQuery.rows[0].species;
+
+      if(speciesName !== speciesOrId) return res.redirect(`/petBreeds/${speciesName}`); //redirect to the correct case
     }
     const result = await pool.query("SELECT * FROM pet_breed WHERE pet_species_id = $1", [speciesId]);
     res.json(result.rows.map((row) => row.pet_breed));

--- a/backend/routes/pets.js
+++ b/backend/routes/pets.js
@@ -2,6 +2,8 @@ import express from 'express';
 import pool from '../config/database.js';
 const router = express.Router();
 
+// router: /pets
+
 // POST add a new pet
 router.post("/", async (req, res, next) => {
   try {


### PR DESCRIPTION
Added sql view on init.sql under the name `active_activity` to target activity logs that are not archived. Affected queries will be using this virtual table. 

router: /activities 

GET
/
/types
/all
/all/:activityTypeOrId
/all/:activityTypeOrId/graph
/deleted

DELETE
/:id

normalized routes with redirects